### PR TITLE
Update config.h

### DIFF
--- a/TFT/src/User/API/config.h
+++ b/TFT/src/User/API/config.h
@@ -164,7 +164,7 @@ extern "C" {
 #define MIN_SIZE_LIMIT            -2000     // machine size less than this will not be parsed.
 #define NAME_MIN_LENGTH           3         // minimum name length
 #define GCODE_MIN_LENGTH          3         // gcode length less than this will not pe parsed.
-#define MIN_POS_LIMIT             0         // position value less than this will not be parsed.
+#define MIN_POS_LIMIT             -2000         // position value less than this will not be parsed.
 #define MIN_TOOL_TEMP             20        // extruder temp less than this will not pe parsed.
 #define MIN_BED_TEMP              20        // bed temp less than this will not pe parsed.
 #define MIN_CHAMBER_TEMP          20        // chamber temp less than this will not pe parsed.


### PR DESCRIPTION


### Requirements

enable the tft sd print pause option to position the print head out of bounds if desired.
the config.ini file would require updating in the pause option where it states that 0 is the minimum allowable position for sd pause.
and the config.h (attached) would need the alteration i've provided)

### Description

<!--

the only problem after this change would be the drag and drop method of tft firmware flash as each tft has its own firmware. 
using vscode configuration.h would allow this change when building in the platform.

-->

### Benefits

<!-- gantry would be clear of the build plate when pausing for use of power loss recovery  -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
